### PR TITLE
Revert "Bump werkzeug from 2.3.3 to 3.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ urllib3==1.26.18
 waitress==2.1.2
 wcwidth==0.2.6
 websocket-client==1.5.1
-Werkzeug==3.0.1
+Werkzeug==2.3.3
 wrapt==1.15.0
 WTForms==3.0.1
 WTForms-SQLAlchemy==0.3


### PR DESCRIPTION
Reverts dvolk/ada2025#66

temporary, due to incompatibilities